### PR TITLE
Add Invalid day of week validation.

### DIFF
--- a/WorkTime/ComplexWorkingWeek.cs
+++ b/WorkTime/ComplexWorkingWeek.cs
@@ -77,7 +77,7 @@ namespace enki.libs.workhours
         /// <param name="end">Horario de término em NodaTime.LocalTime</param>
         public void setWorkDay(int dayOfWeek, LocalTime start, LocalTime end)
         {
-            if (dayOfWeek == (int)IsoDayOfWeek.None)
+            if (dayOfWeek <= (int)IsoDayOfWeek.None || dayOfWeek > (int)IsoDayOfWeek.Sunday)
                 throw new ArgumentException($"The value {dayOfWeek} is not a valid day of week.", nameof(dayOfWeek));
 
             dayPeriods = dayPeriods == null ? new List<WorkingPeriod>() : dayPeriods;

--- a/WorkTime/ComplexWorkingWeek.cs
+++ b/WorkTime/ComplexWorkingWeek.cs
@@ -78,7 +78,7 @@ namespace enki.libs.workhours
         public void setWorkDay(int dayOfWeek, LocalTime start, LocalTime end)
         {
             if (dayOfWeek == (int)IsoDayOfWeek.None)
-                throw new ArgumentException($"The value {dayOfWeek} is not a valid day of week.");
+                throw new ArgumentException($"The value {dayOfWeek} is not a valid day of week.", nameof(dayOfWeek));
 
             dayPeriods = dayPeriods == null ? new List<WorkingPeriod>() : dayPeriods;
             dayPeriods.Add(new WorkingPeriod(dayOfWeek,

--- a/WorkTime/ComplexWorkingWeek.cs
+++ b/WorkTime/ComplexWorkingWeek.cs
@@ -77,6 +77,9 @@ namespace enki.libs.workhours
         /// <param name="end">Horario de término em NodaTime.LocalTime</param>
         public void setWorkDay(int dayOfWeek, LocalTime start, LocalTime end)
         {
+            if (dayOfWeek == (int)IsoDayOfWeek.None)
+                throw new ArgumentException($"The value {dayOfWeek} is not a valid day of week.");
+
             dayPeriods = dayPeriods == null ? new List<WorkingPeriod>() : dayPeriods;
             dayPeriods.Add(new WorkingPeriod(dayOfWeek,
                                              (short)Period.Between(MIDNIGHT, start, PeriodUnits.Minutes).Minutes,

--- a/WorkTimeTests/ComplexWorkingWeekTest.cs
+++ b/WorkTimeTests/ComplexWorkingWeekTest.cs
@@ -1,6 +1,7 @@
 ﻿using enki.libs.workhours;
 using NodaTime;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace WorkTimeTests
@@ -13,7 +14,31 @@ namespace WorkTimeTests
             var startLocalTime = new LocalTime(8, 0);
             var endLocalTime = new LocalTime(18, 0);
             var workingWeek = new ComplexWorkingWeek();
+            var validDayOfWeek = (int)IsoDayOfWeek.Monday;
+
+            workingWeek.setWorkDay(validDayOfWeek, startLocalTime, endLocalTime);
+
+            Assert.True(workingWeek.getPeriods(validDayOfWeek).Any());
+        }
+
+        [Fact]
+        public void SmallestInvalidSetWorkDayTest()
+        {
+            var startLocalTime = new LocalTime(8, 0);
+            var endLocalTime = new LocalTime(18, 0);
+            var workingWeek = new ComplexWorkingWeek();
             var invalidDayOfWeek = (int)IsoDayOfWeek.None;
+
+            Assert.Throws<ArgumentException>("dayOfWeek", () => workingWeek.setWorkDay(invalidDayOfWeek, startLocalTime, endLocalTime));
+        }
+
+        [Fact]
+        public void LongestInvalidSetWorkDayTest()
+        {
+            var startLocalTime = new LocalTime(8, 0);
+            var endLocalTime = new LocalTime(18, 0);
+            var workingWeek = new ComplexWorkingWeek();
+            var invalidDayOfWeek = (int)IsoDayOfWeek.Sunday + 1;
 
             Assert.Throws<ArgumentException>("dayOfWeek", () => workingWeek.setWorkDay(invalidDayOfWeek, startLocalTime, endLocalTime));
         }

--- a/WorkTimeTests/ComplexWorkingWeekTest.cs
+++ b/WorkTimeTests/ComplexWorkingWeekTest.cs
@@ -1,0 +1,21 @@
+﻿using enki.libs.workhours;
+using NodaTime;
+using System;
+using Xunit;
+
+namespace WorkTimeTests
+{
+    public class ComplexWorkingWeekTest
+    {
+        [Fact]
+        public void SetWorkDayTest()
+        {
+            var startLocalTime = new LocalTime(8, 0);
+            var endLocalTime = new LocalTime(18, 0);
+            var workingWeek = new ComplexWorkingWeek();
+            var invalidDayOfWeek = (int)IsoDayOfWeek.None;
+
+            Assert.Throws<ArgumentException>("dayOfWeek", () => workingWeek.setWorkDay(invalidDayOfWeek, startLocalTime, endLocalTime));
+        }
+    }
+}


### PR DESCRIPTION
When WorkingHoursTable is created with a wrong working week containing invalid work day, causes stackoverflow exception when 'WorkingHoursTable.addWorkingHours' method is called.

This PR prevent this exception.