### PR TITLE
Ajuste para permitir processar feriados com conflitos

### DIFF
--- a/WorkTime/RecurrentExceptionsBucket.cs
+++ b/WorkTime/RecurrentExceptionsBucket.cs
@@ -39,14 +39,6 @@ namespace WorkTime
             return AlreadyExists(date.Month, date.Day);
         }
 
-        // [Obsolete("Este método deve ser substituido pelo de lista de períodos.")]
-        // public Tuple<short, short> GetPeriod(LocalDateTime date)
-        // {
-        //     if (!AlreadyExists(date.Month, date.Day)) throw new KeyNotFoundException();
-        //     var data = _bucket.First(b => b.Month == date.Month && b.Day == date.Day);
-        //     return new Tuple<short, short>(data.Start, data.End);
-        // }
-
         public IEnumerable<(short start, short end)> GetPeriods(LocalDateTime date)
         {
             if (!AlreadyExists(date.Month, date.Day)) throw new KeyNotFoundException();

--- a/WorkTime/RecurrentExceptionsBucket.cs
+++ b/WorkTime/RecurrentExceptionsBucket.cs
@@ -5,12 +5,20 @@ using System.Linq;
 
 namespace WorkTime
 {
+    /// <summary>
+    /// Classe para processar os blocos de feriados existentes.
+    /// Esta classe ignora o Ano, ou seja, processa baseado no mês e dia informados.
+    /// </summary>
     public class RecurrentExceptionsBucket
     {
         private bool validateUnique = false;
         private readonly List<RecurrentExceptionItem> _bucket = new List<RecurrentExceptionItem>();
 
         public RecurrentExceptionsBucket() => validateUnique = false;
+        /// <summary>
+        /// Construtor com opção de bloqueio para único feriado por dia
+        /// </summary>
+        /// <param name="validadeUnique">Indica se deve bloquear situações onde existe um feriado no mesmo dia</param>
         public RecurrentExceptionsBucket(bool validadeUnique) => this.validateUnique = validadeUnique;
 
         private bool AlreadyExists(int Month, int Day)
@@ -23,14 +31,7 @@ namespace WorkTime
         {
             var existsDay = AlreadyExists(date.Month, date.Day);
             if (validateUnique && existsDay) throw new Exception("There is already an item to the date indicated in the list.");
-            // if (existsDay)
-            // {
-            //     _bucket.First(b => b.Month == date.Month && b.Day == date.Day).ExtendTo(start, end);
-            // }
-            // else
-            // {
-                _bucket.Add(new RecurrentExceptionItem(date.Month, date.Day, start, end));
-            // }
+            _bucket.Add(new RecurrentExceptionItem(date.Month, date.Day, start, end));
         }
 
         public bool Has(LocalDateTime date)
@@ -38,18 +39,18 @@ namespace WorkTime
             return AlreadyExists(date.Month, date.Day);
         }
 
-        [Obsolete("Este método deve ser substituido pelo de lista de períodos.")]
-        public Tuple<short, short> GetPeriod(LocalDateTime date)
-        {
-            if (!AlreadyExists(date.Month, date.Day)) throw new KeyNotFoundException();
-            var data = _bucket.First(b => b.Month == date.Month && b.Day == date.Day);
-            return new Tuple<short, short>(data.Start, data.End);
-        }
+        // [Obsolete("Este método deve ser substituido pelo de lista de períodos.")]
+        // public Tuple<short, short> GetPeriod(LocalDateTime date)
+        // {
+        //     if (!AlreadyExists(date.Month, date.Day)) throw new KeyNotFoundException();
+        //     var data = _bucket.First(b => b.Month == date.Month && b.Day == date.Day);
+        //     return new Tuple<short, short>(data.Start, data.End);
+        // }
 
-        public IEnumerable<Tuple<short, short>> GetPeriods(LocalDateTime date)
+        public IEnumerable<(short start, short end)> GetPeriods(LocalDateTime date)
         {
             if (!AlreadyExists(date.Month, date.Day)) throw new KeyNotFoundException();
-            return _bucket.Where(b => b.Month == date.Month && b.Day == date.Day).Select(b => new Tuple<short, short>(b.Start, b.End));
+            return _bucket.Where(b => b.Month == date.Month && b.Day == date.Day).Select(b => (b.Start, b.End));
         }
     }
 

--- a/WorkTime/RecurrentExceptionsBucket.cs
+++ b/WorkTime/RecurrentExceptionsBucket.cs
@@ -1,38 +1,77 @@
 ﻿using NodaTime;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace WorkTime
 {
     public class RecurrentExceptionsBucket
     {
-        private readonly Dictionary<int, Dictionary<int, Tuple<short, short>>> _bucket = new Dictionary<int, Dictionary<int, Tuple<short, short>>>();
+        private bool validateUnique = false;
+        private readonly List<RecurrentExceptionItem> _bucket = new List<RecurrentExceptionItem>();
+
+        public RecurrentExceptionsBucket() => validateUnique = false;
+        public RecurrentExceptionsBucket(bool validadeUnique) => this.validateUnique = validadeUnique;
 
         private bool AlreadyExists(int Month, int Day)
         {
-            if (!_bucket.ContainsKey(Month)) return false;
-            return (_bucket[Month].ContainsKey(Day));
+            if (!_bucket.Any(b => b.Month == Month)) return false;
+            return _bucket.Where(b => b.Month == Month).Any(b => b.Day == Day);
         }
 
         public void Add(LocalDateTime date, short start, short end)
         {
-            if (AlreadyExists(date.Month, date.Day)) throw new Exception("There is already an item to the date indicated in the list.");
-            if (!_bucket.ContainsKey(date.Month)) _bucket.Add(date.Month, new Dictionary<int, Tuple<short, short>>());
-            _bucket[date.Month].Add(date.Day, new Tuple<short, short>(start, end));
+            var existsDay = AlreadyExists(date.Month, date.Day);
+            if (validateUnique && existsDay) throw new Exception("There is already an item to the date indicated in the list.");
+            // if (existsDay)
+            // {
+            //     _bucket.First(b => b.Month == date.Month && b.Day == date.Day).ExtendTo(start, end);
+            // }
+            // else
+            // {
+                _bucket.Add(new RecurrentExceptionItem(date.Month, date.Day, start, end));
+            // }
         }
 
         public bool Has(LocalDateTime date)
         {
-            if (!_bucket.ContainsKey(date.Month)) return false;
-            if (!_bucket[date.Month].ContainsKey(date.Day)) return false;
-            return true;
+            return AlreadyExists(date.Month, date.Day);
         }
 
+        [Obsolete("Este método deve ser substituido pelo de lista de períodos.")]
         public Tuple<short, short> GetPeriod(LocalDateTime date)
         {
-            if (!_bucket.ContainsKey(date.Month)) throw new KeyNotFoundException();
-            if (!_bucket[date.Month].ContainsKey(date.Day)) throw new KeyNotFoundException();
-            return _bucket[date.Month][date.Day];
+            if (!AlreadyExists(date.Month, date.Day)) throw new KeyNotFoundException();
+            var data = _bucket.First(b => b.Month == date.Month && b.Day == date.Day);
+            return new Tuple<short, short>(data.Start, data.End);
+        }
+
+        public IEnumerable<Tuple<short, short>> GetPeriods(LocalDateTime date)
+        {
+            if (!AlreadyExists(date.Month, date.Day)) throw new KeyNotFoundException();
+            return _bucket.Where(b => b.Month == date.Month && b.Day == date.Day).Select(b => new Tuple<short, short>(b.Start, b.End));
+        }
+    }
+
+    internal class RecurrentExceptionItem
+    {
+        public int Month { get; private set; }
+        public int Day { get; private set; }
+        public short Start { get; private set; }
+        public short End { get; private set; }
+
+        public RecurrentExceptionItem(int month, int day, short start, short end)
+        {
+            Month = month;
+            Day = day;
+            Start = start;
+            End = end;
+        }
+
+        internal void ExtendTo(short start, short end)
+        {
+            if(start < Start) Start = start;
+            if(end > End) End = end;
         }
     }
 }

--- a/WorkTime/SimpleWorkingDay.cs
+++ b/WorkTime/SimpleWorkingDay.cs
@@ -9,6 +9,7 @@ namespace enki.libs.workhours
     public class SimpleWorkingDay : WorkingDaySlice, IComparable<WorkingDaySlice>
     {
         private static readonly LocalTime MIDNIGHT = new LocalTime(0, 0, 0);
+        private readonly bool useDateOnlyCompare = true;
 
         private readonly LocalDateTime date;
 
@@ -34,16 +35,48 @@ namespace enki.libs.workhours
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="enki.libs.workhours.SimpleWorkingDay"/> class.
+        /// </summary>
+        /// <param name='date'>
+        /// Data a ser incluida no formato DateTime padrao.
+        /// </param>
+        /// <param name='dayStart'>
+        /// Inicio do dia, contado em minutos a partir das 0h do dia.
+        /// </param>
+        /// <param name='dayEnd'>
+        /// Final do dia, contato em minutos a partir das 0h do dia.
+        /// </param>
+        /// <param name='useDateOnlyCompare'>
+        /// Se verdadeiro, a comparação será feita apenas pela data, ignorando os períodos de horários.
+        /// </param>
+        public SimpleWorkingDay(DateTime date, short dayStart, short dayEnd, bool useDateOnlyCompare)
+            : this(DateUtils.ToLocalDateTime(date), dayStart, dayEnd, useDateOnlyCompare)
+        {
+        }
+
+        /// <summary>
         /// Construtor padrão
         /// </summary>
         /// <param name="date">Dia</param>
         /// <param name="dayStart">Hora de inicio, contada em mínutos a partir das 0h do dia</param>
         /// <param name="dayEnd">Hora de término, contara em minutos a partir da 0h do dia</param>
         public SimpleWorkingDay(LocalDateTime date, short dayStart, short dayEnd)
+            : this(date, dayStart, dayEnd, false)
+        {
+        }
+
+        /// <summary>
+        /// Construtor padrão
+        /// </summary>
+        /// <param name="date">Dia</param>
+        /// <param name="dayStart">Hora de inicio, contada em mínutos a partir das 0h do dia</param>
+        /// <param name="dayEnd">Hora de término, contara em minutos a partir da 0h do dia</param>
+        public SimpleWorkingDay(LocalDateTime date, short dayStart, short dayEnd, bool useDateOnlyCompare)
         {
             this.date = date;
             this.dayStart = dayStart;
             this.dayEnd = dayEnd;
+            this.useDateOnlyCompare = useDateOnlyCompare;
         }
 
         /// <summary>
@@ -64,6 +97,17 @@ namespace enki.libs.workhours
         public LocalDateTime getDate()
         {
             return this.date;
+        }
+
+        /// <summary>
+        /// Recupera a data, incluindo calculo com fatia de tempo, referente ao dia no formato UnixTime.
+        /// </summary>
+        private static long getDateWithSlice(WorkingDaySlice workingDay)
+        {
+            var actualDateSeconds = workingDay.getDate().InUtc().ToDateTimeOffset().ToUnixTimeSeconds();
+            var actualStartSeconds = workingDay.getDayStart() * 60;
+            var actualEndSeconds = workingDay.getDayEnd() * 60;
+            return actualDateSeconds + actualStartSeconds + actualEndSeconds;
         }
 
         /// <summary>
@@ -100,7 +144,15 @@ namespace enki.libs.workhours
         /// <returns>-1 se menor que, 0 se igual a ou 1 se maior que</returns>
         public int CompareTo(WorkingDaySlice workingDay)
         {
-            return this.getDate().CompareTo(workingDay.getDate());
+            if (this.useDateOnlyCompare)
+            {
+                return this.getDate().CompareTo(workingDay.getDate());
+            }
+
+            // Como a comparação somente por data não permite o uso de blocos de 
+            // períodos para processamento, fica a possibilidade de comparar dois dias
+            // com possibilidade de conflito desde que não sejam idênticos, incluindo os horários.
+            return getDateWithSlice(this).CompareTo(getDateWithSlice(workingDay));
         }
     }
 }

--- a/WorkTime/WorkingDaySlice.cs
+++ b/WorkTime/WorkingDaySlice.cs
@@ -4,7 +4,7 @@ using System;
 namespace enki.libs.workhours
 {
     /// <summary>
-    /// Interface padr„o que representa um dia de trabalho
+    /// Interface padr√£o que representa um dia de trabalho
     /// </summary>
     public interface WorkingDaySlice : IComparable<WorkingDaySlice>
     {

--- a/WorkTime/WorkingHoursTable.cs
+++ b/WorkTime/WorkingHoursTable.cs
@@ -309,57 +309,6 @@ namespace enki.libs.workhours
             }
             return ret;
         }
-        // /// <summary>
-        // /// Recupera o período útil a ser trabalhado considerando um dia de exceção.
-        // /// No caso, a regra para exceção diz que o período da exceção não é trabalhado, mas se o dia
-        // /// for útil, o restante do dia deve ser contabilizado.
-        // /// Exemplo: Exceção: 10/02/2000 das 00:00 as 12:00, se o dia for útil das 08:00 as 16:00,
-        // ///          ainda deve ser contato o tempo de trabalho das 12:00 as 16:00.
-        // /// </summary>
-        // /// <param name="start">Minuto de inicio do feriado</param>
-        // /// <param name="end">Minuto de fim do feriado</param>
-        // /// <param name="workingPeriods">Períodos de trabalho do dia.</param>
-        // /// <returns>Lista de períodos a serem considerados no tempo de trabalho.</returns>
-        // [Obsolete("Este método não comporta multiplas fatias de tempo do Feriado para cálculo e deve ser descontinuado.")] 
-        // public static List<Tuple<short, short>> GetExceptionDaySlices(short start, short end, List<WorkingPeriod> workingPeriods)
-        // {
-        //     var ret = new List<Tuple<short, short>>();
-        //     foreach (var workingPeriod in workingPeriods)
-        //     {
-        //         if (workingPeriod.startPeriod < start)
-        //         {
-        //             if (workingPeriod.endPeriod <= start)
-        //             {
-        //                 ret.Add(new Tuple<short, short>(workingPeriod.startPeriod, workingPeriod.endPeriod));
-        //             }
-        //             else if (workingPeriod.endPeriod <= end)
-        //             {
-        //                 ret.Add(new Tuple<short, short>(workingPeriod.startPeriod, start));
-        //             }
-        //             else
-        //             {
-        //                 ret.Add(new Tuple<short, short>(workingPeriod.startPeriod, start));
-        //                 ret.Add(new Tuple<short, short>(end, workingPeriod.endPeriod));
-        //             }
-        //         }
-        //         else if (workingPeriod.startPeriod >= end)
-        //         {
-        //             ret.Add(new Tuple<short, short>(workingPeriod.startPeriod, workingPeriod.endPeriod));
-        //         }
-        //         else if (workingPeriod.startPeriod < end)
-        //         {
-        //             if (workingPeriod.endPeriod > end)
-        //             {
-        //                 ret.Add(new Tuple<short, short>(end, workingPeriod.endPeriod));
-        //             }
-        //         }
-        //         else
-        //         {
-        //             ret.Add(new Tuple<short, short>(workingPeriod.startPeriod, workingPeriod.endPeriod));
-        //         }
-        //     }
-        //     return ret;
-        // }
 
         /// <summary>
         /// Devolve a quantidade de horas úteis entre dois DateTime's arredondado p/ baixo (floor)

--- a/WorkTime/WorkingHoursTable.cs
+++ b/WorkTime/WorkingHoursTable.cs
@@ -2,6 +2,7 @@ using enki.libs.workhours.domain;
 using NodaTime;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using WorkTime;
 
 namespace enki.libs.workhours
@@ -214,8 +215,9 @@ namespace enki.libs.workhours
             {
                 // exceções recorrentes
                 workDay[dayIndex] = workDay[dayIndex] == null ? new ComplexWorkingDay() : workDay[dayIndex];
-                var time = RecurrentExceptions.GetPeriod(currentDate);
-                var periods = GetExceptionDaySlices(time.Item1, time.Item2, workingWeek.getPeriods((int)currentDate.DayOfWeek));
+                // var time = RecurrentExceptions.GetPeriod(currentDate);
+                // var periods = GetExceptionDaySlices(time.Item1, time.Item2, workingWeek.getPeriods((int)currentDate.DayOfWeek));
+                var periods = RecurrentExceptions.GetPeriods(currentDate).Select(p => new Tuple<short, short>(p.Item1, p.Item2)).ToList();
                 foreach (var period in periods)
                 {
                     workDay[dayIndex].addDayPart(new SimpleWorkingDay(

--- a/WorkTimeTests/RecurrentExceptionsBucketTests.cs
+++ b/WorkTimeTests/RecurrentExceptionsBucketTests.cs
@@ -7,12 +7,12 @@ namespace WorkTime.Tests
     public class RecurrentExceptionsBucketTests
     {
         [Fact]
-        public void AddTest()
+        public void AddUniqueByDayTest()
         {
             var date2000 = new NodaTime.LocalDateTime(2000, 01, 01, 0, 0);
             var date2001 = new NodaTime.LocalDateTime(2000, 01, 01, 0, 0);
 
-            var recurrentBucket = new RecurrentExceptionsBucket();
+            var recurrentBucket = new RecurrentExceptionsBucket(true);
             try
             {
                 recurrentBucket.Add(date2000, 480, 960);
@@ -32,6 +32,58 @@ namespace WorkTime.Tests
                 Assert.Equal("There is already an item to the date indicated in the list.", e.Message);
             }
         }
+
+        // [Fact]
+        // public void AddSolvingSimpleConflitTest()
+        // {
+        //     var date2000 = new NodaTime.LocalDateTime(2000, 01, 01, 0, 0);
+        //     var date2001 = new NodaTime.LocalDateTime(2000, 01, 01, 0, 0);
+
+        //     var recurrentBucket = new RecurrentExceptionsBucket();
+        //     try
+        //     {
+        //         recurrentBucket.Add(date2000, 480, 960);
+        //         recurrentBucket.Add(date2001, 0, 960);
+        //         Assert.True(true, "Accepted conflited period.");
+                
+        //         var period = recurrentBucket.GetPeriod(date2000);
+        //         Assert.Equal(0, period.Item1);
+        //         Assert.Equal(960, period.Item2);
+        //     }
+        //     catch (Exception e)
+        //     {
+        //         // Assert.Equal("There is already an item to the date indicated in the list.", e.Message);
+        //         Assert.Fail(e.Message);
+        //     }
+        // }
+
+        // [Fact]
+        // public void AddSolvingTwoPeriodConflitTest()
+        // {
+        //     var date2000 = new NodaTime.LocalDateTime(2000, 01, 01, 0, 0);
+        //     var date2001 = new NodaTime.LocalDateTime(2000, 01, 01, 0, 0);
+
+        //     var recurrentBucket = new RecurrentExceptionsBucket();
+        //     try
+        //     {
+        //         recurrentBucket.Add(date2000, 480, 960);
+        //         recurrentBucket.Add(date2001, 1000, 1100);
+        //         Assert.True(true, "Accepted conflited period.");
+                
+        //         var period = recurrentBucket.GetPeriod(date2000);
+        //         Assert.Equal(480, period.Item1);
+        //         Assert.Equal(960, period.Item2);
+                
+        //         // var periods = recurrentBucket.GetPeriods(date2000);
+        //         // Assert.Equal(480, period.Item1);
+        //         // Assert.Equal(960, period.Item2);
+        //     }
+        //     catch (Exception e)
+        //     {
+        //         // Assert.Equal("There is already an item to the date indicated in the list.", e.Message);
+        //         Assert.Fail(e.Message);
+        //     }
+        // }
 
         [Fact]
         public void HasTest()

--- a/WorkTimeTests/RecurrentExceptionsBucketTests.cs
+++ b/WorkTimeTests/RecurrentExceptionsBucketTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace WorkTime.Tests
@@ -19,13 +20,13 @@ namespace WorkTime.Tests
             }
             catch
             {
-                Assert.True(false, "Fail to add recurrent exception.");
+                Assert.Fail("Fail to add recurrent exception.");
             }
 
             try
             {
                 recurrentBucket.Add(date2001, 0, 960);
-                Assert.True(false, "Fail when accept invalid period.");
+                Assert.Fail("Fail when accept invalid period.");
             }
             catch (Exception e)
             {
@@ -33,57 +34,34 @@ namespace WorkTime.Tests
             }
         }
 
-        // [Fact]
-        // public void AddSolvingSimpleConflitTest()
-        // {
-        //     var date2000 = new NodaTime.LocalDateTime(2000, 01, 01, 0, 0);
-        //     var date2001 = new NodaTime.LocalDateTime(2000, 01, 01, 0, 0);
+        /// <summary>
+        /// Em situações onde há um conflito na quebra, a recuperação irá trazer em períodos separados,
+        /// mesmo que conflitando, a classe que calcula a diferença de horas agora deve considerar essa
+        /// situação e processar todos os pedaços para chegar ao valor final.
+        /// </summary>
+        [Fact]
+        public void AddSolvingSimpleConflictTest()
+        {
+            var date2000 = new NodaTime.LocalDateTime(2000, 01, 01, 0, 0);
+            var date2001 = new NodaTime.LocalDateTime(2000, 01, 01, 0, 0);
 
-        //     var recurrentBucket = new RecurrentExceptionsBucket();
-        //     try
-        //     {
-        //         recurrentBucket.Add(date2000, 480, 960);
-        //         recurrentBucket.Add(date2001, 0, 960);
-        //         Assert.True(true, "Accepted conflited period.");
-                
-        //         var period = recurrentBucket.GetPeriod(date2000);
-        //         Assert.Equal(0, period.Item1);
-        //         Assert.Equal(960, period.Item2);
-        //     }
-        //     catch (Exception e)
-        //     {
-        //         // Assert.Equal("There is already an item to the date indicated in the list.", e.Message);
-        //         Assert.Fail(e.Message);
-        //     }
-        // }
-
-        // [Fact]
-        // public void AddSolvingTwoPeriodConflitTest()
-        // {
-        //     var date2000 = new NodaTime.LocalDateTime(2000, 01, 01, 0, 0);
-        //     var date2001 = new NodaTime.LocalDateTime(2000, 01, 01, 0, 0);
-
-        //     var recurrentBucket = new RecurrentExceptionsBucket();
-        //     try
-        //     {
-        //         recurrentBucket.Add(date2000, 480, 960);
-        //         recurrentBucket.Add(date2001, 1000, 1100);
-        //         Assert.True(true, "Accepted conflited period.");
-                
-        //         var period = recurrentBucket.GetPeriod(date2000);
-        //         Assert.Equal(480, period.Item1);
-        //         Assert.Equal(960, period.Item2);
-                
-        //         // var periods = recurrentBucket.GetPeriods(date2000);
-        //         // Assert.Equal(480, period.Item1);
-        //         // Assert.Equal(960, period.Item2);
-        //     }
-        //     catch (Exception e)
-        //     {
-        //         // Assert.Equal("There is already an item to the date indicated in the list.", e.Message);
-        //         Assert.Fail(e.Message);
-        //     }
-        // }
+            var recurrentBucket = new RecurrentExceptionsBucket();
+            try
+            {
+                recurrentBucket.Add(date2000, 480, 960);
+                recurrentBucket.Add(date2001, 0, 960);
+                var period = recurrentBucket.GetPeriods(date2000);
+                Assert.Equal(2, period.Count());
+                Assert.Equal(480, period.First().start);
+                Assert.Equal(960, period.First().end);
+                Assert.Equal(0, period.Last().start);
+                Assert.Equal(960, period.Last().end);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail(e.Message);
+            }
+        }
 
         [Fact]
         public void HasTest()
@@ -108,12 +86,12 @@ namespace WorkTime.Tests
             var recurrentBucket = new RecurrentExceptionsBucket();
             recurrentBucket.Add(date2000, 480, 960);
 
-            Assert.Equal(new Tuple<short, short>(480, 960), recurrentBucket.GetPeriod(date2000));
-            Assert.Equal(new Tuple<short, short>(480, 960), recurrentBucket.GetPeriod(date2001));
+            Assert.Equal(new List<(short, short)> { (480, 960) }, recurrentBucket.GetPeriods(date2000));
+            Assert.Equal(new List<(short, short)> { (480, 960) }, recurrentBucket.GetPeriods(date2001));
             try
             {
-                recurrentBucket.GetPeriod(new NodaTime.LocalDateTime(2005, 10, 05, 0, 0));
-                Assert.True(false, "Fail to get period.");
+                recurrentBucket.GetPeriods(new NodaTime.LocalDateTime(2005, 10, 05, 0, 0));
+                Assert.Fail("Fail to get period.");
             }
             catch (KeyNotFoundException)
             {
@@ -121,7 +99,7 @@ namespace WorkTime.Tests
             }
             catch (Exception e)
             {
-                Assert.True(false, e.Message);
+                Assert.Fail(e.Message);
             }
         }
     }

--- a/WorkTimeTests/WorkingHoursUtilsTest.cs
+++ b/WorkTimeTests/WorkingHoursUtilsTest.cs
@@ -3,6 +3,7 @@ using enki.libs.workhours.domain;
 using NodaTime;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace enki.tests.libs.date
@@ -423,35 +424,47 @@ namespace enki.tests.libs.date
 
             short start = h_0000;
             short end = h_0000;
-            var ret = WorkingHoursTable.GetExceptionDaySlices(start, end, workingPeriods);
-            Assert.Equal(2, ret.Count);
-            Assert.Equal(h_0900, ret[0].Item1);
-            Assert.Equal(h_1200, ret[0].Item2);
-            Assert.Equal(h_1300, ret[1].Item1);
-            Assert.Equal(h_1800, ret[1].Item2);
+            // var ret = WorkingHoursTable.GetExceptionDaySlices(start, end, workingPeriods);
+            var workingSlices = workingPeriods.Select(w => (w.startPeriod, w.endPeriod)).ToList();
+            var sliceBlock = new List<(short, short)> { (start, end)};
+            var ret = WorkingHoursTable.GetExceptionDaySlices(sliceBlock, workingSlices);
+            Assert.Equal(2, ret.Count());
+            var firstItem = ret.First();
+            var secondItem = ret.Last();
+            Assert.Equal(h_0900, firstItem.start);
+            Assert.Equal(h_1200, firstItem.end);
+            Assert.Equal(h_1300, secondItem.start);
+            Assert.Equal(h_1800, secondItem.end);
 
             start = h_0900;
             end = h_1200;
-            ret = WorkingHoursTable.GetExceptionDaySlices(start, end, workingPeriods);
+            sliceBlock = new List<(short, short)> { (start, end)};
+            ret = WorkingHoursTable.GetExceptionDaySlices(sliceBlock, workingSlices);
             Assert.Single(ret);
-            Assert.Equal(h_1300, ret[0].Item1);
-            Assert.Equal(h_1800, ret[0].Item2);
+            firstItem = ret.First();
+            Assert.Equal(h_1300, firstItem.start);
+            Assert.Equal(h_1800, firstItem.end);
 
             start = h_1300;
             end = h_1800;
-            ret = WorkingHoursTable.GetExceptionDaySlices(start, end, workingPeriods);
+            sliceBlock = new List<(short, short)> { (start, end)};
+            ret = WorkingHoursTable.GetExceptionDaySlices(sliceBlock, workingSlices);
             Assert.Single(ret);
-            Assert.Equal(h_0900, ret[0].Item1);
-            Assert.Equal(h_1200, ret[0].Item2);
+            firstItem = ret.First();
+            Assert.Equal(h_0900, firstItem.start);
+            Assert.Equal(h_1200, firstItem.end);
 
             start = h_1000;
             end = h_1400;
-            ret = WorkingHoursTable.GetExceptionDaySlices(start, end, workingPeriods);
-            Assert.Equal(2, ret.Count);
-            Assert.Equal(h_0900, ret[0].Item1);
-            Assert.Equal(h_1000, ret[0].Item2);
-            Assert.Equal(h_1400, ret[1].Item1);
-            Assert.Equal(h_1800, ret[1].Item2);
+            sliceBlock = new List<(short, short)> { (start, end)};
+            ret = WorkingHoursTable.GetExceptionDaySlices(sliceBlock, workingSlices);
+            Assert.Equal(2, ret.Count());
+            firstItem = ret.First();
+            secondItem = ret.Last();
+            Assert.Equal(h_0900, firstItem.start);
+            Assert.Equal(h_1000, firstItem.end);
+            Assert.Equal(h_1400, secondItem.start);
+            Assert.Equal(h_1800, secondItem.end);
 
         }
 


### PR DESCRIPTION
- Ajuste para permitir conflito de feriado
  - Ajustado para processar uma lista de períodos por Data, ao invés de um único item.
- Ajuste para correção dos testes quebrados
- Ajuste para incluir teste e correção para 2 partes de feriado no mesmo dia
- Ajuste para incluir teste de feriado Recorrente conflitante no mesmo dia
