### PR TITLE
fix: ajuste para evitar exceção de Index fora do tamanho do array

### DIFF
--- a/WorkTime/WorkingHoursTable.cs
+++ b/WorkTime/WorkingHoursTable.cs
@@ -395,6 +395,8 @@ namespace enki.libs.workhours
 
             int secondsDifference = 0;
 
+            var minutes = getWorkingMinutesBetween(start, end);
+
             DateTime lastDayStart = new DateTime(end.Year, end.Month, end.Day, 0, 0, 0).AddMinutes(workDay[endIndex].getMinStartDayPart());
             DateTime lastDayEnd = new DateTime(end.Year, end.Month, end.Day, 0, 0, 0).AddMinutes(workDay[endIndex].getMaxEndDayPart());
 
@@ -405,9 +407,7 @@ namespace enki.libs.workhours
             DateTime firstDayEnd = new DateTime(start.Year, start.Month, start.Day, 0, 0, 0).AddMinutes(workDay[startIndex].getMaxEndDayPart());
 
             if (start > firstDayStart && start < firstDayEnd)
-                secondsDifference -= start.Second;
-
-            var minutes = getWorkingMinutesBetween(start, end);
+                secondsDifference -= start.Second;            
 
             // Converte minutos para segundos e soma a diferença
             var totalSeconds = (minutes * 60) + secondsDifference;


### PR DESCRIPTION
### Problema

O método de `getWorkingSecondsBetween` tem trechos de verificações para confirmar se os segundos das datas de inicio e fim estão dentro do período de horas úteis para serem calculados, em uma dessas verificações a data de fim é buscada dentro do lista de WorkDays e nesse ponto ocorreu o acesso em um index fora do array. O problema era que essa verificações estavam sendo feitas antes de chamar o calculo base em minutos com o método `getWorkingMinutesBetween` dentro desse método a lista de WorkDays era expandida, logo evitaria o acesso a um index fora do array.

### Solução

A solução foi mover o calculo base em minutos com o método `getWorkingMinutesBetween` e colocar ele antes das verificações, para garantir que a lista de WorkDays já estaria expandida no momento de acesso ao index do array