### PR TITLE
Update .net framework to LTS + fix issue

### DIFF
--- a/WorkTime/ComplexWorkingWeek.cs
+++ b/WorkTime/ComplexWorkingWeek.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
-using NodaTime;
 using enki.libs.workhours.domain;
+using NodaTime;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace enki.libs.workhours
@@ -30,6 +30,19 @@ namespace enki.libs.workhours
 
         private List<WorkingPeriod> dayPeriods { get; set; }
 
+        private static short ToEndMinutes(LocalTime end)
+        {
+            // se o fim do período é o "fim do dia", consideramos os minutos presentes em 24:00 (1440)
+            if (end == HOURS_235959)
+                return 24 * 60; // 1440
+
+            return (short)Period.Between(MIDNIGHT, end, PeriodUnits.Minutes).Minutes;
+        }
+
+        private static short ToStartMinutes(LocalTime start)
+        {
+            return (short)Period.Between(MIDNIGHT, start, PeriodUnits.Minutes).Minutes;
+        }
 
         /// <summary>
         /// Recupera a lista de periodos da semana toda
@@ -91,9 +104,11 @@ namespace enki.libs.workhours
                 throw new ArgumentException($"The value {dayOfWeek} is not a valid day of week.", nameof(dayOfWeek));
 
             dayPeriods = dayPeriods == null ? new List<WorkingPeriod>() : dayPeriods;
-            dayPeriods.Add(new WorkingPeriod(dayOfWeek,
-                                             (short)Period.Between(MIDNIGHT, start, PeriodUnits.Minutes).Minutes,
-                                             (short)Period.Between(MIDNIGHT, end, PeriodUnits.Minutes).Minutes));
+            dayPeriods.Add(new WorkingPeriod(
+                dayOfWeek,
+                ToStartMinutes(start),
+                ToEndMinutes(end)
+            ));
         }
 
         /// <summary>

--- a/WorkTime/WorkTime.csproj
+++ b/WorkTime/WorkTime.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0;</TargetFrameworks>
-    <Version>1.4.1</Version>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="NodaTime" Version="3.1.9" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;netstandard2.0;</TargetFrameworks>
+		<Version>1.4.1</Version>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="NodaTime" Version="3.1.9" />
+	</ItemGroup>
 </Project>

--- a/WorkTimeTests/WorkTimeTests.csproj
+++ b/WorkTimeTests/WorkTimeTests.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net6.0;</TargetFrameworks>
-    <Version>1.4.1</Version>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\WorkTime\WorkTime.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<Version>1.4.1</Version>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+		<PackageReference Include="xunit" Version="2.5.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\WorkTime\WorkTime.csproj" />
+	</ItemGroup>
 </Project>

--- a/WorkTimeTests/WorkingHoursUtilsTest.cs
+++ b/WorkTimeTests/WorkingHoursUtilsTest.cs
@@ -106,6 +106,34 @@ namespace enki.tests.libs.date
         }
 
         [Fact]
+        public void testWorkingSecondsBetween2()
+        {
+            /// Recupera uma semana padrão de 7 dias com vinte e quatro horas de trabalho por dia em 1 periodo por dia.
+            WorkingWeek workingWeek = ComplexWorkingWeek.getWeek24x7();
+
+            WorkingHoursTable table = new WorkingHoursTable(
+                workingWeek,
+                new LocalDateTime(2000, 1, 3, 0, 0, 0),
+                new LocalDateTime(2000, 1, 4, 0, 0, 0)
+            );
+
+            const int SECS_PER_MIN = 60;
+
+            // 20:55 até 00:00
+            // 2000-01-01 20:55:00 -> 2000-01-02 00:00:00 = 3h 5m = 185 minutos
+            // Em segundos: 185 * 60 = 11100
+            var seconds = table.getWorkingSecondsBetween(
+                    new DateTime(2000, 1, 1, 20, 55, 0),
+                    new DateTime(2000, 1, 2, 0, 0, 0)
+                );
+
+            Assert.Equal(
+                (185 * SECS_PER_MIN),
+                seconds
+            );
+        }
+
+        [Fact]
         public void testWorkingMinutesBetween()
         {
             WorkingWeek workingWeek = ComplexWorkingWeek.getWeek8x7();
@@ -158,6 +186,77 @@ namespace enki.tests.libs.date
             tabela = new WorkingHoursTable(workingWeek, new LocalDateTime(1978, 7, 14, 0, 0, 0), new LocalDateTime(2009, 9, 15, 0, 0, 0));
             Assert.Equal(11373 * 8 * 60, tabela.getWorkingMinutesBetween(new DateTime(1978, 7, 29, 0, 0, 0, 0), new DateTime(2009, 9, 17, 0, 0,
                     0, 0)));
+        }
+
+        [Fact]
+        public void testWorkingMinutesBetween2()
+        {
+            /// Recupera uma semana padrão de 7 dias com vinte e quatro horas de trabalho por dia em 1 periodo por dia.
+            /// Trabalho no período das 00:00 às 23:59
+            WorkingWeek workingWeek = ComplexWorkingWeek.getWeek24x7();
+
+            WorkingHoursTable table = new WorkingHoursTable(
+                workingWeek,
+                new LocalDateTime(2000, 1, 3, 0, 0, 0),
+                new LocalDateTime(2000, 1, 4, 0, 0, 0)
+            );
+
+            const int MINS_PER_HOUR = 60;
+
+            // 20:55 até 00:00
+            // 2000-01-01 20:55:00 -> 2000-01-02 00:00:00 = 3h 5m
+            Assert.Equal(
+                (MINS_PER_HOUR * 3) + 5, // 185
+                table.getWorkingMinutesBetween(new DateTime(2000, 1, 1, 20, 55, 0), new DateTime(2000, 1, 2, 0, 0, 0))
+            );
+        }
+
+        [Fact]
+        public void testWorkingMinutesBetween3()
+        {
+            // Recupera uma semana padrão de 7 dias com vinte e quatro horas de trabalho por dia em 1 periodo por dia.
+            // Trabalho no período das 00:00 às 23:59
+            WorkingWeek workingWeek = ComplexWorkingWeek.getWeek24x7();
+
+            WorkingHoursTable table = new WorkingHoursTable(
+                workingWeek,
+                new LocalDateTime(2000, 1, 3, 0, 0, 0),
+                new LocalDateTime(2000, 1, 4, 0, 0, 0)
+            );
+
+            const int MINS_PER_HOUR = 60;
+            var result = table.getWorkingMinutesBetween(new DateTime(2000, 1, 1, 20, 55, 0), new DateTime(2000, 1, 2, 0, 1, 0));
+
+            // 20:55 até 00:01
+            // 2000-01-01 20:55:00 -> 2000-01-02 00:01:00 = 3h 6m
+            Assert.Equal(
+                (MINS_PER_HOUR * 3) + 6, // 186
+                result
+            );
+        }
+
+        [Fact]
+        public void testWorkingMinutesBetween4()
+        {
+            // Recupera uma semana padrão de 7 dias com vinte e quatro horas de trabalho por dia em 1 periodo por dia.
+            // Trabalho no período das 00:00 às 23:59
+            WorkingWeek workingWeek = ComplexWorkingWeek.getWeek24x7();
+
+            WorkingHoursTable table = new WorkingHoursTable(
+                workingWeek,
+                new LocalDateTime(2000, 1, 3, 0, 0, 0),
+                new LocalDateTime(2000, 1, 4, 0, 0, 0)
+            );
+
+            const int MINS_PER_HOUR = 60;
+            var result = table.getWorkingMinutesBetween(new DateTime(2000, 1, 1, 20, 55, 0), new DateTime(2000, 1, 1, 23, 59, 59));
+
+            // 20:55 até 00:01
+            // 2000-01-01 20:55:00 -> 2000-01-02 00:01:00 = 3h 6m
+            Assert.Equal(
+                (MINS_PER_HOUR * 3) + 4, // 184
+                result
+            );
         }
 
         [Fact]

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
-    "sdk": {
-          "version": "6.0.404",
-          "rollForward": "latestFeature"      
-    }
+  "sdk": {
+    "version": "8.0.119",
+    "rollForward": "latestFeature"
+  }
 }


### PR DESCRIPTION
**O que foi ajustado**
Corrigi um problema no cálculo de horas de trabalho quando o período ia até 00:00:00.
Antes, o método tratava o final do dia como 23:59:59 e isso fazia perder 1 minuto (ficava 1439 em vez de 1440).
Agora adicionei uma validação para que, quando for esse caso, o sistema considere 1440 minutos corretamente.

**Outros ajustes**
Atualizei o projeto para usar o .NET 8.0 (LTS).