### PR TITLE
PROD-2860 - Corrige segundos negativos no cálculo de tempo útil (getWorkingSecondsBetween)

### DIFF
--- a/WorkTime/ComplexWorkingDay.cs
+++ b/WorkTime/ComplexWorkingDay.cs
@@ -207,6 +207,34 @@ namespace enki.libs.workhours
         }
 
         /// <summary>
+        /// Verifica se um determinado horario esta dentro de alguma das partes uteis do dia.
+        /// A comparacao é feita na granularidade de minutos, sendo o inicio da fatia inclusivo
+        /// e o final exclusivo. Ex: fatia das 08:00 as 12:00 contem 08:00:30 mas nao contem 12:00:30.
+        /// </summary>
+        /// <returns>
+        /// Verdadeiro se o horario informado pertence a algum periodo util do dia.
+        /// </returns>
+        public bool isWithinWorkingPeriod(LocalTime time)
+        {
+            //Recupera a quantidade de minutos entre as 00:00 do dia e a hora a ser validada.
+            int timeMinutes = (int)Period.Between(
+                new LocalDateTime(2000, 01, 01, 0, 0, 0),
+                new LocalDateTime(2000, 01, 01, time.Hour, time.Minute, time.Second),
+                PeriodUnits.Minutes
+            ).Minutes;
+
+            foreach (SimpleWorkingDay slice in this.dayParts)
+            {
+                if (timeMinutes >= slice.getDayStart() && timeMinutes < slice.getDayEnd())
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Recupera o numero total de minutos uteis do dia ate um determinado horario.
         /// </summary>
         /// <returns>

--- a/WorkTime/WorkTime.csproj
+++ b/WorkTime/WorkTime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net10.0;netstandard2.0;</TargetFrameworks>
-		<Version>1.4.2</Version>
+		<Version>1.4.3</Version>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NodaTime" Version="3.1.9" />

--- a/WorkTime/WorkingHoursTable.cs
+++ b/WorkTime/WorkingHoursTable.cs
@@ -397,22 +397,21 @@ namespace enki.libs.workhours
 
             var minutes = getWorkingMinutesBetween(start, end);
 
-            DateTime lastDayStart = new DateTime(end.Year, end.Month, end.Day, 0, 0, 0).AddMinutes(workDay[endIndex].getMinStartDayPart());
-            DateTime lastDayEnd = new DateTime(end.Year, end.Month, end.Day, 0, 0, 0).AddMinutes(workDay[endIndex].getMaxEndDayPart());
-
-            if (end > lastDayStart && end < lastDayEnd)
+            // O ajuste dos segundos parciais só pode ser aplicado quando o horário está dentro de um
+            // período útil real do dia. Não basta estar entre o início do primeiro período e o fim do
+            // último (envelope do dia): horários dentro de um intervalo entre períodos (ex: pausa de
+            // almoço) não são tempo útil e o ajuste geraria valores negativos ou inflados.
+            if (workDay[endIndex].isWithinWorkingPeriod(new LocalTime(end.Hour, end.Minute, end.Second)))
                 secondsDifference += end.Second;
 
-            DateTime firstDayStart = new DateTime(start.Year, start.Month, start.Day, 0, 0, 0).AddMinutes(workDay[startIndex].getMinStartDayPart());
-            DateTime firstDayEnd = new DateTime(start.Year, start.Month, start.Day, 0, 0, 0).AddMinutes(workDay[startIndex].getMaxEndDayPart());
-
-            if (start > firstDayStart && start < firstDayEnd)
-                secondsDifference -= start.Second;            
+            if (workDay[startIndex].isWithinWorkingPeriod(new LocalTime(start.Hour, start.Minute, start.Second)))
+                secondsDifference -= start.Second;
 
             // Converte minutos para segundos e soma a diferença
             var totalSeconds = (minutes * 60) + secondsDifference;
 
-            return totalSeconds;
+            // Proteção: tempo útil nunca pode ser negativo, mesmo com dados de entrada inconsistentes.
+            return totalSeconds < 0 ? 0 : totalSeconds;
         }
 
 

--- a/WorkTimeTests/WorkingSecondsBetweenGapTest.cs
+++ b/WorkTimeTests/WorkingSecondsBetweenGapTest.cs
@@ -131,5 +131,98 @@ namespace enki.tests.libs.date
 
             Assert.Equal(1800, seconds);
         }
+
+        [Fact]
+        public void GetWorkingSecondsBetween_EventoCruzandoOGapInteiro_SomaOsSegundosDosDoisLados()
+        {
+            var table = CreateTableWithLunchGap();
+
+            // Início 10s antes do fim do primeiro período (11:59:50) e fim 10s após o retorno (14:00:10).
+            // Tempo útil real = 10s (11:59:50 -> 12:00:00) + 10s (14:00:00 -> 14:00:10) = 20s.
+            var seconds = table.getWorkingSecondsBetween(
+                new DateTime(2026, 7, 14, 11, 59, 50),
+                new DateTime(2026, 7, 14, 14, 0, 10)
+            );
+
+            Assert.Equal(20, seconds);
+        }
+
+        [Fact]
+        public void GetWorkingSecondsBetween_InicioNoMinutoExatoDoFimDoPeriodo_NaoDeveSubtrairSegundos()
+        {
+            var table = CreateTableWithLunchGap();
+
+            // O período da manhã termina às 12:00, então 12:00:30 já está dentro do gap.
+            // Tempo útil real = 30min (14:00:00 -> 14:30:00) = 1800s.
+            var seconds = table.getWorkingSecondsBetween(
+                new DateTime(2026, 7, 14, 12, 0, 30),
+                new DateTime(2026, 7, 14, 14, 30, 0)
+            );
+
+            Assert.Equal(1800, seconds);
+        }
+
+        [Fact]
+        public void GetWorkingSecondsBetween_GapCriadoPorFeriadoParcial_DeveSerZero()
+        {
+            // Dia útil de período único (08:00-18:00) com feriado parcial das 10:00 as 16:00.
+            // O feriado recorta o dia em [08:00-10:00] e [16:00-18:00], criando um gap no meio do envelope.
+            var week = new ComplexWorkingWeek();
+            for (var day = (int)IsoDayOfWeek.Monday; day <= (int)IsoDayOfWeek.Friday; day++)
+            {
+                week.setWorkPeriod(day, day, new LocalTime(8, 0), new LocalTime(18, 0));
+            }
+
+            var holidays = new SortedSet<WorkingDaySlice>
+            {
+                // 10:00 = 600 minutos | 16:00 = 960 minutos
+                new SimpleWorkingDay(new DateTime(2026, 7, 14), (short)600, (short)960)
+            };
+
+            var table = new WorkingHoursTable(
+                week, new List<WorkingDaySlice>(), holidays,
+                new LocalDateTime(2026, 7, 13, 0, 0, 0), new LocalDateTime(2026, 7, 14, 0, 0, 0)
+            );
+
+            // Evento inteiro dentro do gap criado pelo feriado: tempo útil real = 0.
+            var seconds = table.getWorkingSecondsBetween(
+                new DateTime(2026, 7, 14, 12, 0, 59),
+                new DateTime(2026, 7, 14, 12, 45, 0)
+            );
+
+            Assert.Equal(0, seconds);
+        }
+
+        [Fact]
+        public void GetWorkingSecondsBetween_MultiDiaComInicioEFimEmGaps_ContaApenasOsPeriodosUteis()
+        {
+            var table = CreateTableWithLunchGap();
+
+            // 17/07/2026 é sexta e 20/07/2026 é segunda (sábado e domingo sem expediente).
+            // Início no gap da sexta e fim no gap da segunda.
+            // Tempo útil real = tarde de sexta (4h) + manhã de segunda (4h) = 8h = 28800s.
+            // Bug atual: retorna 28755 (subtrai os 45s do início mesmo estando no gap).
+            var seconds = table.getWorkingSecondsBetween(
+                new DateTime(2026, 7, 17, 12, 30, 45),
+                new DateTime(2026, 7, 20, 12, 40, 0)
+            );
+
+            Assert.Equal(28800, seconds);
+        }
+
+        [Fact]
+        public void GetWorkingSecondsBetween_FimAnteriorAoInicio_DeveSerZero()
+        {
+            var table = CreateTableWithLunchGap();
+
+            // Proteção contra dados de entrada inconsistentes (ex: relógios dessincronizados
+            // gravando fim anterior ao início). O tempo útil nunca pode ser negativo.
+            var seconds = table.getWorkingSecondsBetween(
+                new DateTime(2026, 7, 14, 10, 0, 59),
+                new DateTime(2026, 7, 14, 10, 0, 0)
+            );
+
+            Assert.Equal(0, seconds);
+        }
     }
 }

--- a/WorkTimeTests/WorkingSecondsBetweenGapTest.cs
+++ b/WorkTimeTests/WorkingSecondsBetweenGapTest.cs
@@ -1,0 +1,135 @@
+using enki.libs.workhours;
+using enki.libs.workhours.domain;
+using NodaTime;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace enki.tests.libs.date
+{
+    /// <summary>
+    /// Testes do cálculo de segundos úteis quando o dia possui mais de um período de trabalho
+    /// (gap/intervalo entre períodos, ex: pausa de almoço ou expediente noturno que cruza o dia).
+    ///
+    /// Cenário de bug (PROD): eventos que iniciam dentro do gap retornavam segundos NEGATIVOS
+    /// (ex: -57), pois o ajuste de segundos de getWorkingSecondsBetween considera apenas o
+    /// envelope do dia (getMinStartDayPart..getMaxEndDayPart) e não os períodos úteis reais.
+    /// </summary>
+    public class WorkingSecondsBetweenGapTest
+    {
+        /// <summary>
+        /// Semana seg-sex com dois períodos por dia: 08:00-12:00 e 14:00-18:00 (gap de almoço).
+        /// </summary>
+        private static WorkingHoursTable CreateTableWithLunchGap()
+        {
+            var week = new ComplexWorkingWeek();
+            for (var day = (int)IsoDayOfWeek.Monday; day <= (int)IsoDayOfWeek.Friday; day++)
+            {
+                week.setWorkPeriod(day, day, new LocalTime(8, 0), new LocalTime(12, 0));
+                week.setWorkPeriod(day, day, new LocalTime(14, 0), new LocalTime(18, 0));
+            }
+
+            return new WorkingHoursTable(
+                week, new List<WorkingDaySlice>(), new SortedSet<WorkingDaySlice>(),
+                new LocalDateTime(2026, 7, 13, 0, 0, 0), new LocalDateTime(2026, 7, 14, 0, 0, 0)
+            );
+        }
+
+        /// <summary>
+        /// Configuração real que reproduziu o bug em produção (caixa 2303):
+        /// períodos que cruzam o dia (23:00 -> 10:59 do dia seguinte), gerando em cada dia útil
+        /// os períodos [00:00-10:59] e [23:00-23:59] com um gap de ~12h no meio do envelope.
+        /// </summary>
+        private static WorkingHoursTable CreateTableWithOvernightPeriods()
+        {
+            var week = new ComplexWorkingWeek();
+            week.setWorkPeriod((int)IsoDayOfWeek.Monday, (int)IsoDayOfWeek.Tuesday, new LocalTime(23, 0), new LocalTime(10, 59));
+            week.setWorkPeriod((int)IsoDayOfWeek.Tuesday, (int)IsoDayOfWeek.Wednesday, new LocalTime(23, 0), new LocalTime(10, 59));
+            week.setWorkPeriod((int)IsoDayOfWeek.Wednesday, (int)IsoDayOfWeek.Thursday, new LocalTime(23, 0), new LocalTime(10, 59));
+            week.setWorkPeriod((int)IsoDayOfWeek.Thursday, (int)IsoDayOfWeek.Friday, new LocalTime(23, 0), new LocalTime(10, 59));
+            week.setWorkPeriod((int)IsoDayOfWeek.Friday, (int)IsoDayOfWeek.Monday, new LocalTime(23, 0), new LocalTime(11, 0));
+
+            return new WorkingHoursTable(
+                week, new List<WorkingDaySlice>(), new SortedSet<WorkingDaySlice>(),
+                new LocalDateTime(2026, 6, 15, 0, 0, 0), new LocalDateTime(2026, 6, 16, 0, 0, 0)
+            );
+        }
+
+        [Fact]
+        public void GetWorkingSecondsBetween_EventoRealDaCaixa2303DentroDoGap_DeveSerZero()
+        {
+            var table = CreateTableWithOvernightPeriods();
+
+            // Evento real 103683746: 16/06/2026 (terça) 11:04:59 -> 11:06:02.
+            // O evento inteiro está dentro do gap 10:59-23:00, portanto o tempo útil é 0.
+            // Bug atual: retorna -57 (0 minutos úteis + 2s do fim - 59s do início).
+            var seconds = table.getWorkingSecondsBetween(
+                new DateTime(2026, 6, 16, 11, 4, 59),
+                new DateTime(2026, 6, 16, 11, 6, 2)
+            );
+
+            Assert.Equal(0, seconds);
+        }
+
+        [Fact]
+        public void GetWorkingSecondsBetween_InicioEFimDentroDoGapDeAlmoco_DeveSerZero()
+        {
+            var table = CreateTableWithLunchGap();
+
+            // 14/07/2026 é terça. Evento inteiro dentro do gap 12:00-14:00: tempo útil real = 0.
+            // Bug atual: retorna -59 (subtrai os segundos do início por estar dentro do envelope do dia).
+            var seconds = table.getWorkingSecondsBetween(
+                new DateTime(2026, 7, 14, 12, 30, 59),
+                new DateTime(2026, 7, 14, 12, 45, 0)
+            );
+
+            Assert.Equal(0, seconds);
+        }
+
+        [Fact]
+        public void GetWorkingSecondsBetween_InicioNoGapCruzandoMinuto_DeveSerZero()
+        {
+            var table = CreateTableWithLunchGap();
+
+            // Evento de 1 segundo dentro do gap, cruzando a fronteira do minuto (:59 -> :00).
+            // Tempo útil real = 0. Bug atual: retorna -59.
+            var seconds = table.getWorkingSecondsBetween(
+                new DateTime(2026, 7, 14, 12, 30, 59),
+                new DateTime(2026, 7, 14, 12, 31, 0)
+            );
+
+            Assert.Equal(0, seconds);
+        }
+
+        [Fact]
+        public void GetWorkingSecondsBetween_InicioNoGapEFimNoPeriodoSeguinte_ContaApenasTempoUtil()
+        {
+            var table = CreateTableWithLunchGap();
+
+            // Início no gap (12:30:59) e fim 30s após o retorno do expediente (14:00:30).
+            // Tempo útil real = 30s (14:00:00 -> 14:00:30). Bug atual: retorna -29.
+            var seconds = table.getWorkingSecondsBetween(
+                new DateTime(2026, 7, 14, 12, 30, 59),
+                new DateTime(2026, 7, 14, 14, 0, 30)
+            );
+
+            Assert.Equal(30, seconds);
+        }
+
+        [Fact]
+        public void GetWorkingSecondsBetween_FimDentroDoGap_NaoDeveSomarSegundosDoFim()
+        {
+            var table = CreateTableWithLunchGap();
+
+            // Início em período útil (11:30:00) e fim dentro do gap (12:30:45).
+            // Tempo útil real = 30min (11:30:00 -> 12:00:00) = 1800s.
+            // Bug atual: retorna 1845 (soma os 45s do fim por estar dentro do envelope do dia).
+            var seconds = table.getWorkingSecondsBetween(
+                new DateTime(2026, 7, 14, 11, 30, 0),
+                new DateTime(2026, 7, 14, 12, 30, 45)
+            );
+
+            Assert.Equal(1800, seconds);
+        }
+    }
+}


### PR DESCRIPTION
## O que foi feito

Corrige o `getWorkingSecondsBetween`, que retornava valores negativos (ex: `00:00:-59`
na exportação de dados e na api-client) quando o evento começava dentro de um intervalo
não útil entre dois períodos de trabalho do mesmo dia. Acontecia em caixas com pausa de
almoço (08-12 / 14-18) e em caixas com expediente cruzando o dia, como 23:00 às 10:59
do dia seguinte.

A causa: o ajuste de segundos parciais só verificava se o horário estava entre o início
do primeiro período e o fim do último período do dia. Um horário dentro do intervalo
(almoço, por exemplo) passava nessa verificação e tinha os segundos subtraídos
indevidamente. Como o evento tinha 0 minutos úteis, o resultado ficava negativo.
O mesmo defeito também inflava o resultado em até 59s quando o fim do evento caía
dentro do intervalo.

### Alterações

- Novo método `isWithinWorkingPeriod` em `ComplexWorkingDay`, que verifica se um horário
  está dentro de algum período útil real do dia.
- `getWorkingSecondsBetween` agora usa esse método para decidir se aplica o ajuste de
  segundos parciais, no lugar da verificação antiga.
- O retorno nunca é negativo (proteção contra datas de início/fim inconsistentes).
- Novos testes em `WorkingSecondsBetweenGapTest` cobrindo os cenários com intervalo,
  incluindo o caso real que gerou o problema em produção. Suíte completa passando (75 testes).
- Versão 1.4.2 -> 1.4.3.

Nenhuma mudança em `getWorkingMinutesBetween` e `addWorkingHours`, que seguem com o
mesmo comportamento.